### PR TITLE
Fix Block Hyperlinks for OPS 3.3

### DIFF
--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -26,7 +26,7 @@
 					<ul>
 						{foreach from=$browseCategories item=browseCategory}
 							<li class="category_{$browseCategory->getId()}{if $browseCategory->getParentId()} is_sub{/if}{if $browseBlockSelectedCategory == $browseCategory->getPath()} current{/if}">
-								<a href="{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="catalog" op="category" path=$browseCategory->getPath()|escape}">
+								<a href="{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="preprints" op="category" path=$browseCategory->getPath()|escape}">
 									{$browseCategory->getLocalizedTitle()|escape}
 								</a>
 							</li>


### PR DESCRIPTION
Replaced the word "catalog" to "preprints" on line 29