### PR TITLE
Fix Block Highlilght Issue

### DIFF
--- a/BrowseBlockPlugin.php
+++ b/BrowseBlockPlugin.php
@@ -52,7 +52,7 @@ class BrowseBlockPlugin extends BlockPlugin
         $router = $request->getRouter();
 
         $requestedCategoryPath = null;
-        if ($router->getRequestedPage($request) . '/' . $router->getRequestedOp($request) == 'catalog/category') {
+        if ($router->getRequestedPage($request) . '/' . $router->getRequestedOp($request) == 'preprints/category') {
             $args = $router->getRequestedArgs($request);
             $requestedCategoryPath = reset($args);
         }


### PR DESCRIPTION
Replaced the word "catalog" to "preprints" in browseblockplugin.php on line 55. It fixes the issue with category highlight when after clicking a category in the browse block after opening the page.